### PR TITLE
Add skeleton for backend, frontend, module configs and compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # MoonDust
+
+This repository provides a basic project skeleton with the following structure:
+
+- `backend/` – placeholder for the backend implementation.
+- `frontend/nextjs/` – Next.js application configured with TailwindCSS.
+- `frontend/angular/` – Angular application configured with TailwindCSS.
+- `module-config/` – configuration files for modules such as Nginx and Keycloak.
+- `docker-compose.yml` – orchestrates the services: frontend, backend, Keycloak, and Nginx.
+
+Use `docker-compose up` to start the development environment.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine
+CMD ["sh", "-c", "echo Backend placeholder"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,1 @@
+# Backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3.8'
+
+services:
+  frontend-next:
+    build: ./frontend/nextjs
+    command: npm run dev
+    volumes:
+      - ./frontend/nextjs:/app
+    working_dir: /app
+    ports:
+      - "3000:3000"
+
+  frontend-angular:
+    build: ./frontend/angular
+    command: npm start
+    volumes:
+      - ./frontend/angular:/app
+    working_dir: /app
+    ports:
+      - "4200:4200"
+
+  backend:
+    build: ./backend
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./backend:/app
+    working_dir: /app
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:latest
+    environment:
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin
+    command: start-dev
+    ports:
+      - "8081:8080"
+
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ./module-config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "80:80"
+    depends_on:
+      - frontend-next
+      - backend
+
+networks:
+  default:
+    driver: bridge

--- a/frontend/angular/Dockerfile
+++ b/frontend/angular/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install -g @angular/cli && npm install
+COPY . .
+CMD ["npm", "start"]

--- a/frontend/angular/README.md
+++ b/frontend/angular/README.md
@@ -1,0 +1,1 @@
+# Angular frontend with Tailwind

--- a/frontend/angular/package.json
+++ b/frontend/angular/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "angular-app",
+  "private": true,
+  "scripts": {
+    "start": "ng serve",
+    "build": "ng build"
+  },
+  "dependencies": {
+    "@angular/core": "latest"
+  },
+  "devDependencies": {
+    "tailwindcss": "latest"
+  }
+}

--- a/frontend/nextjs/Dockerfile
+++ b/frontend/nextjs/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+CMD ["npm", "run", "dev"]

--- a/frontend/nextjs/README.md
+++ b/frontend/nextjs/README.md
@@ -1,0 +1,1 @@
+# Next.js frontend with Tailwind

--- a/frontend/nextjs/package.json
+++ b/frontend/nextjs/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "nextjs-app",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "tailwindcss": "latest",
+    "autoprefixer": "latest",
+    "postcss": "latest"
+  }
+}

--- a/module-config/keycloak/README.md
+++ b/module-config/keycloak/README.md
@@ -1,0 +1,1 @@
+This directory holds configuration files for Keycloak.

--- a/module-config/nginx/nginx.conf
+++ b/module-config/nginx/nginx.conf
@@ -1,0 +1,17 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://frontend:3000;
+        }
+
+        location /api/ {
+            proxy_pass http://backend:8080/;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- provide basic project layout with backend, frontend (Next.js and Angular) and config directories
- add Dockerfiles for each service and `docker-compose.yml`
- supply Nginx configuration and placeholder Keycloak config
- update README with project overview

## Testing
- `docker-compose` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d208fa810832697f356727f96c964