### PR TITLE
Add environment variables and PostgreSQL setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,23 @@
+# Environment variables for the MoonDust stack
+
+# Ports
+NGINX_PORT=80
+FRONTEND_NEXT_PORT=3000
+FRONTEND_ANGULAR_PORT=4200
+BACKEND_PORT=8080
+KEYCLOAK_PORT=8081
+POSTGRES_PORT=5432
+
+# Database credentials
+POSTGRES_DB=moondust
+POSTGRES_USER=moondust
+POSTGRES_PASSWORD=moondust
+
+# Database schemas
+POSTGRES_SCHEMA_SYS=md_sys
+POSTGRES_SCHEMA_APP=md_app
+POSTGRES_SCHEMA_KEYCLOAK=keycloak
+
+# Keycloak admin user
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=admin

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository provides a basic project skeleton with the following structure:
 - `frontend/nextjs/` – Next.js application configured with TailwindCSS.
 - `frontend/angular/` – Angular application configured with TailwindCSS.
 - `module-config/` – configuration files for modules such as Nginx and Keycloak.
-- `docker-compose.yml` – orchestrates the services: frontend, backend, Keycloak, and Nginx.
+- `docker-compose.yml` – orchestrates the services: frontend, backend, Keycloak, PostgreSQL, and Nginx.
+- `.env` – environment variables used by the compose file.
 
 Use `docker-compose up` to start the development environment.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,2 +1,5 @@
+# Simple backend image based on Alpine Linux
 FROM alpine
+
+# The backend is not implemented yet; print a placeholder message
 CMD ["sh", "-c", "echo Backend placeholder"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,47 +1,74 @@
+# Docker Compose file orchestrating the application stack
 version: '3.8'
 
 services:
+  # PostgreSQL database used by the application and Keycloak
+  postgres:
+    # Official PostgreSQL image providing the application database
+    image: postgres:latest
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ./initdb:/docker-entrypoint-initdb.d
+    ports:
+      - "${POSTGRES_PORT}:5432"
+
   frontend-next:
+    # Next.js development server
     build: ./frontend/nextjs
     command: npm run dev
     volumes:
       - ./frontend/nextjs:/app
     working_dir: /app
     ports:
-      - "3000:3000"
+      - "${FRONTEND_NEXT_PORT}:3000"
 
   frontend-angular:
+    # Angular development server
     build: ./frontend/angular
     command: npm start
     volumes:
       - ./frontend/angular:/app
     working_dir: /app
     ports:
-      - "4200:4200"
+      - "${FRONTEND_ANGULAR_PORT}:4200"
 
   backend:
+    # Placeholder backend container
     build: ./backend
     ports:
-      - "8080:8080"
+      - "${BACKEND_PORT}:8080"
     volumes:
       - ./backend:/app
     working_dir: /app
 
   keycloak:
+    # Authentication server using Keycloak
     image: quay.io/keycloak/keycloak:latest
     environment:
-      - KEYCLOAK_ADMIN=admin
-      - KEYCLOAK_ADMIN_PASSWORD=admin
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      KC_DB: postgres
+      KC_DB_URL_HOST: postgres
+      KC_DB_URL_DATABASE: ${POSTGRES_DB}
+      KC_DB_SCHEMA: ${POSTGRES_SCHEMA_KEYCLOAK}
+      KC_DB_USERNAME: ${POSTGRES_USER}
+      KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
     command: start-dev
     ports:
-      - "8081:8080"
+      - "${KEYCLOAK_PORT}:8080"
+    depends_on:
+      - postgres
 
   nginx:
+    # Reverse proxy forwarding requests to frontend and backend
     image: nginx:latest
     volumes:
       - ./module-config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
-      - "80:80"
+      - "${NGINX_PORT}:80"
     depends_on:
       - frontend-next
       - backend

--- a/frontend/angular/Dockerfile
+++ b/frontend/angular/Dockerfile
@@ -1,6 +1,15 @@
+# Build image for the Angular frontend using Node 18
 FROM node:18-alpine
+
+# Create application directory
 WORKDIR /app
+
+# Install Angular CLI globally and project dependencies
 COPY package.json ./
 RUN npm install -g @angular/cli && npm install
+
+# Copy application source code
 COPY . .
+
+# Start the Angular development server
 CMD ["npm", "start"]

--- a/frontend/nextjs/Dockerfile
+++ b/frontend/nextjs/Dockerfile
@@ -1,6 +1,15 @@
+# Build image for the Next.js frontend using Node 18
 FROM node:18-alpine
+
+# Create application directory
 WORKDIR /app
+
+# Install dependencies defined in package.json
 COPY package.json ./
 RUN npm install
+
+# Copy application source code
 COPY . .
+
+# Start the development server
 CMD ["npm", "run", "dev"]

--- a/initdb/init.sql
+++ b/initdb/init.sql
@@ -1,0 +1,13 @@
+-- Initialization script for PostgreSQL
+-- Creates schemas for administration, application, and Keycloak
+
+CREATE SCHEMA IF NOT EXISTS md_sys;
+CREATE SCHEMA IF NOT EXISTS md_app;
+CREATE SCHEMA IF NOT EXISTS keycloak;
+
+-- Example application table
+CREATE TABLE IF NOT EXISTS md_app.md_task (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/module-config/keycloak/README.md
+++ b/module-config/keycloak/README.md
@@ -1,1 +1,3 @@
 This directory holds configuration files for Keycloak.
+Currently the Keycloak instance is configured through environment
+variables in `docker-compose.yml`.

--- a/module-config/nginx/nginx.conf
+++ b/module-config/nginx/nginx.conf
@@ -1,15 +1,19 @@
+# Basic Nginx configuration acting as a reverse proxy
 worker_processes 1;
 
 events { worker_connections 1024; }
 
 http {
     server {
+        # Listen on the HTTP port
         listen 80;
 
+        # Proxy requests to the Next.js frontend
         location / {
             proxy_pass http://frontend:3000;
         }
 
+        # Forward API calls to the backend service
         location /api/ {
             proxy_pass http://backend:8080/;
         }


### PR DESCRIPTION
## Summary
- document `.env` usage in README
- comment all configuration files
- provide `.env` with variables used by compose
- configure docker-compose with PostgreSQL and Keycloak schemas
- add initialization script creating `md_sys`, `md_app`, and `keycloak` schemas

## Testing
- `docker-compose` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d227e9c488326a7c0295725e311b8