### PR TITLE
Add minimal Node frontend and backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/node_modules/

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 This repository provides a basic project skeleton with the following structure:
 
-- `backend/` – placeholder for the backend implementation.
-- `frontend/angular/` – Angular application configured with TailwindCSS.
+- `backend/` – minimal Express backend exposing a small API.
+- `frontend/angular/` – simple Node frontend serving static HTML.
 - `module-config/` – configuration files for modules such as Nginx and Keycloak.
 - `docker-compose.yml` – orchestrates the services: frontend, backend, Keycloak, PostgreSQL, and Nginx.
 - `.env` – environment variables used by the compose file.
 
-Nginx requires users to authenticate through Keycloak before the Angular front-end is served.
+Nginx requires users to authenticate through Keycloak before the frontend is served.
 
 Use `docker-compose up` to start the development environment.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,11 @@
-# Simple backend image based on Alpine Linux
-FROM alpine
+# Minimal backend container using Node
+FROM node:18-alpine
 
-# The backend is not implemented yet; print a placeholder message
-CMD ["sh", "-c", "echo Backend placeholder"]
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install
+
+COPY . .
+
+CMD ["npm", "start"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,1 +1,5 @@
 # Backend
+
+This directory contains a small Express application exposing a single API
+endpoint at `/api/hello`. The service listens on port `8080` inside the
+container.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "frontend",
+  "name": "backend",
   "version": "1.0.0",
-  "private": true,
+  "main": "server.js",
   "scripts": {
     "start": "node server.js"
   },

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const port = 8080;
+
+app.get('/api/hello', (req, res) => {
+  res.json({ message: 'Hello from backend' });
+});
+
+app.listen(port, () => {
+  console.log(`Backend listening on port ${port}`);
+});

--- a/frontend/angular/Dockerfile
+++ b/frontend/angular/Dockerfile
@@ -1,15 +1,11 @@
-# Build image for the Angular frontend using Node 18
+# Minimal frontend container using Node
 FROM node:18-alpine
 
-# Create application directory
 WORKDIR /app
 
-# Install Angular CLI globally and project dependencies
 COPY package.json ./
-RUN npm install -g @angular/cli && npm install
+RUN npm install
 
-# Copy application source code
 COPY . .
 
-# Start the Angular development server
 CMD ["npm", "start"]

--- a/frontend/angular/README.md
+++ b/frontend/angular/README.md
@@ -1,1 +1,4 @@
-# Angular frontend with Tailwind
+# Frontend
+
+A simple Node application that serves static HTML from the `public` directory.
+The server listens on port `4200`.

--- a/frontend/angular/public/index.html
+++ b/frontend/angular/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>MoonDust Frontend</title>
+</head>
+<body>
+  <h1>Hello from MoonDust Frontend</h1>
+</body>
+</html>

--- a/frontend/angular/server.js
+++ b/frontend/angular/server.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const port = 4200;
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.listen(port, () => {
+  console.log(`Frontend listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- supply an Express backend with a `/api/hello` endpoint
- add a simple Node-based frontend serving static HTML
- update Dockerfiles to install dependencies and run the new apps
- document the new components in READMEs
- ignore `node_modules` directories

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684d3029e8e88326a2a0ce77f987413d