### PR TITLE
Add Keycloak realm import and friendly error pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,15 @@ for authentication before serving content, but it no longer waits for Keycloak
 to be available at startup. Keycloak continues to rely on PostgreSQL for its
 database.
 
+## Keycloak Realm Import
+
+The `keycloak` service automatically imports the example realm defined in
+`module-config/keycloak/example-realm.json`. The realm contains a sample client
+named `example-client` used by the Nginx configuration for authentication.
+
+## Friendly Error Pages
+
+Nginx serves custom pages for `400`, `404`, and `500` errors from the
+`static-html` directory. Feel free to modify these pages to fit your branding.
+
 Use `docker-compose up` to start the development environment.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,9 @@ services:
       KC_DB_SCHEMA: ${POSTGRES_SCHEMA_KEYCLOAK}
       KC_DB_USERNAME: ${POSTGRES_USER}
       KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
-    command: start-dev
+    command: start-dev --import-realm
+    volumes:
+      - ./module-config/keycloak:/opt/keycloak/data/import:ro
     networks:
       - internal
     ports:

--- a/module-config/keycloak/example-realm.json
+++ b/module-config/keycloak/example-realm.json
@@ -1,0 +1,12 @@
+{
+  "realm": "example",
+  "enabled": true,
+  "clients": [
+    {
+      "clientId": "example-client",
+      "publicClient": true,
+      "redirectUris": ["*"],
+      "webOrigins": ["*"]
+    }
+  ]
+}

--- a/module-config/nginx/nginx.conf
+++ b/module-config/nginx/nginx.conf
@@ -44,9 +44,17 @@ http {
         add_header Permissions-Policy "geolocation=(), microphone=()" always;
         add_header Server "";  # Remove Server header
 
-        # Custom error page
-        error_page 403 404 500 502 503 504 /custom_50x.html;
-        location = /custom_50x.html {
+        # Custom error pages
+        error_page 404 /404.html;
+        error_page 500 502 503 504 /500.html;
+        error_page 400 /400.html;
+        location = /404.html {
+            root /usr/share/nginx/html;
+        }
+        location = /500.html {
+            root /usr/share/nginx/html;
+        }
+        location = /400.html {
             root /usr/share/nginx/html;
         }
 

--- a/static-html/400.html
+++ b/static-html/400.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Bad Request</title>
+</head>
+<body>
+    <h1>Bad request (400)</h1>
+    <p>The request could not be understood by the server.</p>
+</body>
+</html>

--- a/static-html/404.html
+++ b/static-html/404.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Page Not Found</title>
+</head>
+<body>
+    <h1>Oops! Page not found (404)</h1>
+    <p>The page you are looking for may have been moved or deleted.</p>
+</body>
+</html>

--- a/static-html/500.html
+++ b/static-html/500.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Server Error</title>
+</head>
+<body>
+    <h1>Something went wrong (500)</h1>
+    <p>Please try again later.</p>
+</body>
+</html>

--- a/static-html/index.html
+++ b/static-html/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>MoonDust</title>
+</head>
+<body>
+    <h1>Welcome to MoonDust</h1>
+    <p>This is an example static page served by Nginx.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- import a realm with `example-client` when Keycloak starts
- use custom 400, 404 and 500 error pages in nginx
- include simple static HTML pages
- document the new setup

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4ed3e6788326971aa0358ffb0a6d