### PR TITLE
Improve nginx error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ named `example-client` used by the Nginx configuration for authentication.
 ## Friendly Error Pages
 
 Nginx serves custom pages for `400`, `404`, and `500` errors from the
-`static-html` directory. Feel free to modify these pages to fit your branding.
+`static-html` directory and intercepts upstream errors as well. Requests are
+redirected to Keycloak using a relative `/realms/...` path so the configuration
+works regardless of the external host name. Feel free to modify these pages to
+fit your branding.
 
 Use `docker-compose up` to start the development environment.

--- a/module-config/nginx/nginx.conf
+++ b/module-config/nginx/nginx.conf
@@ -89,6 +89,7 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_intercept_errors on;  # Show friendly error pages on 404/500
         }
 
         ##################################
@@ -96,7 +97,8 @@ http {
         ##################################
         location / {
             auth_request /auth;
-            error_page 401 =302 http://localhost:8081/realms/example/protocol/openid-connect/auth?client_id=example-client&redirect_uri=$scheme://$host$request_uri;
+            # Redirect unauthenticated users through the same host to Keycloak
+            error_page 401 =302 /realms/example/protocol/openid-connect/auth?client_id=example-client&redirect_uri=$scheme://$host$request_uri;
 
             root /usr/share/nginx/html;
             index index.html;


### PR DESCRIPTION
## Summary
- fix Keycloak redirect URL in `nginx.conf`
- intercept upstream errors for `/realms/` requests
- document relative redirect behaviour in the README

## Testing
- `docker-compose config` *(fails: command not found)*
- `nginx -t -c module-config/nginx/nginx.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d5170ae7c83268286887a7abbdb3d