### PR TITLE
Fix config paths after directory restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository provides a basic project skeleton with the following structure:
 - `module-config/` – configuration files for modules such as Nginx and Keycloak.
 - `docker-compose.yml` – orchestrates the services: Keycloak, PostgreSQL, and Nginx.
 - `.env` – environment variables used by the compose file.
+- `frontend/` – static HTML pages served by Nginx located under `frontend/html/static-html`.
 
 Each service can start independently. Nginx still redirects users to Keycloak
 for authentication before serving content, but it no longer waits for Keycloak
@@ -20,7 +21,7 @@ named `example-client` used by the Nginx configuration for authentication.
 ## Friendly Error Pages
 
 Nginx serves custom pages for `400`, `404`, and `500` errors from the
-`static-html` directory and intercepts upstream errors as well. Requests are
+`frontend/html/static-html` directory and intercepts upstream errors as well. Requests are
 redirected to Keycloak using a relative `/realms/...` path so the configuration
 works regardless of the external host name. Feel free to modify these pages to
 fit your branding.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - "${NGINX_PORT}:80"
     volumes:
       - ./module-config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./html:/usr/share/nginx/html:ro
+      - ./frontend/html/static-html:/usr/share/nginx/html:ro
     depends_on:
       - keycloak
     networks:


### PR DESCRIPTION
## Summary
- update docker compose mount path for static html
- document new static files directory in README

## Testing
- `docker-compose -f docker-compose.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7ea3da2483268ba9fd094cad2191