### PR TITLE
Add stack details and metabase service

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Structure du projet avec plusieurs services conteneurisés.
 
+## Stack technique
+
+- **Backend** : NestJS (Node + TypeScript)
+- **Frontend** : React.js + TypeScript
+- **Gestion des droits** : Casbin pour un contrôle fin des accès
+- **Dashboarding** : Metabase
+
 ## Dossiers
 
 - `frontend` : interface utilisateur.
@@ -9,6 +16,7 @@ Structure du projet avec plusieurs services conteneurisés.
 - `modules` : modules ou SDK additionnels.
 - `nginx` : proxy Nginx.
 - `keycloak` : gestion des identités.
+- `metabase` : service de dashboarding.
 
 Chaque dossier contient un `Dockerfile` minimal.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,7 @@ services:
     build: ./keycloak
     ports:
       - "8080:8080"
+  metabase:
+    build: ./metabase
+    ports:
+      - "3001:3000"

--- a/metabase/Dockerfile
+++ b/metabase/Dockerfile
@@ -1,0 +1,1 @@
+FROM metabase/metabase:latest

--- a/metabase/README.md
+++ b/metabase/README.md
@@ -1,0 +1,3 @@
+# Metabase
+
+Instance Metabase pour le dashboarding.


### PR DESCRIPTION
## Summary
- document stack details (NestJS, React + TS, Casbin, Metabase)
- add Metabase service definition
- include Metabase in project docker-compose

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eeae2ed9c8326b596890c48b49211