### PR TITLE
Configure Nginx redirect to Keycloak

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -13,10 +13,29 @@ http {
     sendfile on;
     keepalive_timeout 65;
 
+    upstream backend {
+        server backend:5000;
+    }
+
+    upstream frontend {
+        server frontend:3000;
+    }
+
     server {
         listen 80;
-        location / {
-            return 200 'Nginx server';
+
+        # Redirect root requests to Keycloak for authentication
+        location = / {
+            return 302 http://keycloak:8080/;
+        }
+
+        # Proxy frontend and backend services
+        location /frontend/ {
+            proxy_pass http://frontend/;
+        }
+
+        location /backend/ {
+            proxy_pass http://backend/;
         }
     }
 }


### PR DESCRIPTION
## Summary
- setup Nginx as a reverse proxy for frontend and backend
- redirect root requests to Keycloak

## Testing
- `node backend/server.js` *(logs Backend running on port 5000)*
- `node frontend/server.js` *(logs Frontend running on port 3000)*

------
https://chatgpt.com/codex/tasks/task_e_684eebe2b8488326a7f543618fe92387