### PR TITLE
Add basic layout skeleton

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>MoonDust App</title>
+  <style>
+    body {
+      margin: 0;
+      height: 100vh;
+      display: grid;
+      grid-template-rows: 40px 1fr 30px;
+      font-family: sans-serif;
+    }
+    header {
+      background: #1e1e1e;
+      color: #fff;
+      padding: 0 10px;
+      display: flex;
+      align-items: center;
+    }
+    footer {
+      background: #1e1e1e;
+      color: #fff;
+      padding: 0 10px;
+      display: flex;
+      align-items: center;
+    }
+    .workspace {
+      display: grid;
+      grid-template-columns: 20% 1fr 10%;
+      height: 100%;
+    }
+    .sidebar-left {
+      background: #252526;
+      color: #ccc;
+      padding: 10px;
+    }
+    .main {
+      background: #1e1e1e;
+      color: #ccc;
+      padding: 10px;
+    }
+    .sidebar-right {
+      background: #333333;
+      color: #ccc;
+      padding: 10px;
+    }
+  </style>
+</head>
+<body>
+  <header>MoonDust Header</header>
+  <div class="workspace">
+    <nav class="sidebar-left">Menu gauche</nav>
+    <main class="main" id="content">Affichage dynamique</main>
+    <aside class="sidebar-right">Menu droit</aside>
+  </div>
+  <footer>MoonDust Footer</footer>
+</body>
+</html>

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,5 +1,24 @@
 const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
 const server = http.createServer((req, res) => {
-  res.end('Frontend service');
+  // Serve the main page for the root route
+  if (req.url === '/' || req.url === '/index.html') {
+    const filePath = path.join(__dirname, 'index.html');
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        res.writeHead(500);
+        res.end('Error loading page');
+      } else {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(data);
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end('Not Found');
+  }
 });
+
 server.listen(3000, () => console.log('Frontend running on port 3000'));


### PR DESCRIPTION
## Summary
- add simple HTML layout inspired by VSCode
- serve the new HTML from the frontend Node server

## Testing
- `node frontend/server.js`

------
https://chatgpt.com/codex/tasks/task_e_684eeea299cc83268750cac5bd8718c3