### PR TITLE
Add initial project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # MoonDust Définition
 
 Ce projet a pour objectif d'être une Méta-Application, une sorte de Plateforme qui sera ensuite paramétrée pour avoir une identité pour un métier spécifique.
-Un assemblage de technolgoie, de composant et d'outil d'une façon cohérente pour pouvoir faire des actions
+Un assemblage de technologie, de composants et d'outils d'une façon cohérente pour pouvoir faire des actions.
 
+## Structure du dépôt
+
+- **frontend/** : contiendra le code de la partie interface utilisateur. On y trouve un `Dockerfile` très commenté pour faciliter la prise en main.
+- **backend/** : hébergera la logique serveur de l'application. Là encore, un `Dockerfile` explique chaque étape de la construction de l'image.
+- **database/** : contient l'environnement lié à la base PostgreSQL. Le `Dockerfile` détaille les variables d'environnement utilisées pour initialiser la base.
+
+Chacun de ces dossiers pourra être complété par la suite (code, scripts, configurations). Pour l'instant ils servent uniquement de squelette afin de préparer la suite du développement.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,23 @@
+# Dockerfile pour le dossier Backend
+# Ce fichier permet de construire l'image Docker de la partie serveur de l'application
+# Les commentaires détaillent chaque instruction pour faciliter la compréhension
+
+# Nous partons d'une image officielle de Node, adaptée aux applications serveur en JavaScript/TypeScript
+FROM node:20
+
+# Définition du répertoire de travail à l'intérieur du conteneur
+WORKDIR /app
+
+# Copie des fichiers de gestion des dépendances
+COPY package*.json ./
+
+# Installation des dépendances du backend
+RUN npm ci || npm install
+
+# Copie du reste du code source
+COPY . .
+
+# La commande par défaut peut être personnalisée lors du lancement du conteneur
+CMD ["npm", "run", "start:prod"]
+
+# Fin du Dockerfile backend

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,0 +1,26 @@
+# Dockerfile pour la base de données
+# Cette image se base sur la version officielle de PostgreSQL
+# Les commentaires donnent des explications détaillées pour faciliter l'utilisation
+
+# Image officielle PostgreSQL recommandée pour la production
+FROM postgres:16
+
+# Les variables d'environnement suivantes permettent d'initialiser la base de données
+# POSTGRES_USER : nom d'utilisateur par défaut
+# POSTGRES_PASSWORD : mot de passe de l'utilisateur
+# POSTGRES_DB : nom de la base de données créée au démarrage
+# Ici, on se contente de les déclarer pour montrer comment les utiliser
+# Elles pourront être remplacées ou complétées dans un fichier docker-compose ou à
+# l'exécution via la ligne de commande
+ENV POSTGRES_USER=appuser \
+    POSTGRES_PASSWORD=apppassword \
+    POSTGRES_DB=appdb
+
+# Optionnel : ajout d'un script d'initialisation placé dans le dossier docker-entrypoint-initdb.d
+# Tout fichier .sql ou .sh présent dans ce répertoire sera exécuté au démarrage
+# COPY init-db.sh /docker-entrypoint-initdb.d/
+
+# Aucune commande CMD supplémentaire n'est nécessaire : l'image postgres
+# lance automatiquement le serveur PostgreSQL
+
+# Fin du Dockerfile database

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,27 @@
+# Dockerfile pour le dossier Frontend
+# Ce fichier sert à construire l'image Docker utilisée pour développer et exécuter la partie Front de l'application
+# Les commentaires sont très verbeux afin d'expliquer chaque étape pour les débutants
+
+# Utilisation d'une image Node officielle comme base
+# Node est couramment utilisé pour les applications web frontend
+FROM node:20
+
+# Définition du dossier de travail à l'intérieur du conteneur
+WORKDIR /app
+
+# Copie des fichiers package.json et package-lock.json (s'ils existent) pour installer les dépendances en premier
+# Cela permet de profiter du cache Docker si les dépendances n'ont pas changé entre deux constructions
+COPY package*.json ./
+
+# Installation des dépendances du projet
+# On utilise npm ci pour une installation reproductible si package-lock.json est présent
+RUN npm ci || npm install
+
+# Copie du reste des fichiers du projet dans le conteneur
+COPY . .
+
+# Par défaut, cette image ne lance pas l'application
+# L'utilisateur pourra spécifier la commande à exécuter lors du lancement du conteneur
+CMD ["npm", "start"]
+
+# Fin du Dockerfile frontend


### PR DESCRIPTION
## Summary
- create empty `frontend`, `backend` and `database` folders
- add verbose Dockerfiles in each folder
- update main README to document the skeleton structure

## Testing
- `ls -R`

------
https://chatgpt.com/codex/tasks/task_e_6873bb31a00c8326a0c53333f73686a1