### PR TITLE
Add Keycloak demo realm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Un assemblage de technologie, de composants et d'outils d'une façon cohérente 
 - **frontend/** : contiendra le code de la partie interface utilisateur. On y trouve un `Dockerfile` très commenté pour faciliter la prise en main.
 - **backend/** : hébergera la logique serveur de l'application. Là encore, un `Dockerfile` explique chaque étape de la construction de l'image.
 - **database/** : contient l'environnement lié à la base PostgreSQL. Le `Dockerfile` détaille les variables d'environnement utilisées pour initialiser la base.
+- **keycloak/** : fournit Keycloak pour l'authentification et la gestion des utilisateurs. Un `Dockerfile` importe automatiquement le realm de démonstration `demo`.
 
 ### Schémas de base de données
 

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,0 +1,20 @@
+# Dockerfile pour le dossier Keycloak
+# Fournit un environnement Keycloak de developpement avec import automatique du realm "demo"
+
+# Utilisation de l'image officielle Keycloak
+FROM quay.io/keycloak/keycloak:24.0
+
+# Variables d'environnement pour l'administrateur
+ENV KEYCLOAK_ADMIN=admin \
+    KEYCLOAK_ADMIN_PASSWORD=admin
+
+WORKDIR /opt/keycloak
+
+# Copie du fichier de configuration du realm
+COPY realm-demo.json /opt/keycloak/data/import/realm-demo.json
+
+# Lancement de Keycloak en mode developpement avec import du realm
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
+CMD ["start-dev", "--import-realm"]
+
+# Fin du Dockerfile Keycloak

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -1,0 +1,15 @@
+# Keycloak
+
+Ce dossier fournit la configuration necessaire pour executer Keycloak au sein du projet.
+Le `Dockerfile` se base sur l'image officielle et importe automatiquement un realm de demonstration nomme `demo`.
+
+## Construction et lancement
+
+```bash
+docker build -t moondust-keycloak .
+docker run --rm -p 8080:8080 moondust-keycloak
+```
+
+Les variables `KEYCLOAK_ADMIN` et `KEYCLOAK_ADMIN_PASSWORD` definissent le compte administrateur cree au demarrage (valeurs par defaut : `admin` / `admin`).
+
+Le realm `demo` definit dans `realm-demo.json` contient un utilisateur `demo` dont le mot de passe est `demo`.

--- a/keycloak/realm-demo.json
+++ b/keycloak/realm-demo.json
@@ -1,0 +1,21 @@
+{
+  "realm": "demo",
+  "enabled": true,
+  "displayName": "Demo Realm",
+  "users": [
+    {
+      "username": "demo",
+      "enabled": true,
+      "email": "demo@example.com",
+      "firstName": "Demo",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "demo",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Keycloak configuration under `keycloak/`
- import a demo realm automatically
- document Keycloak usage in `README.md` and in its own folder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873c0d6199c832680af75513ff3ae2d