### PR TITLE
Add nginx frontend and sample tile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ Lors de l'initialisation de PostgreSQL, trois schémas sont créés automatiquem
 - `metaappsys` : tables communes et globales.
 
 Chacun de ces dossiers pourra être complété par la suite (code, scripts, configurations). Pour l'instant ils servent uniquement de squelette afin de préparer la suite du développement.
+
+## Lancer un exemple
+
+Un `docker-compose.yml` minimal est fourni pour prévisualiser la page d'accueil servie par Nginx.
+Depuis la racine du dépôt, exécutez :
+
+```bash
+docker compose up --build
+```
+
+La page sera alors disponible sur `http://localhost:8080` et présente un système de tuiles avec cinq tailles (`mini`, `petit`, `moyen`, `grand`, `max`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  frontend:
+    build: ./frontend
+    ports:
+      - "8080:80"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,27 +1,10 @@
-# Dockerfile pour le dossier Frontend
-# Ce fichier sert à construire l'image Docker utilisée pour développer et exécuter la partie Front de l'application
-# Les commentaires sont très verbeux afin d'expliquer chaque étape pour les débutants
+# Dockerfile pour servir le frontend via Nginx
+FROM nginx:alpine
 
-# Utilisation d'une image Node officielle comme base
-# Node est couramment utilisé pour les applications web frontend
-FROM node:20
+# Copie de la configuration personnalisée
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-# Définition du dossier de travail à l'intérieur du conteneur
-WORKDIR /app
+# Copie des fichiers statiques
+COPY . /usr/share/nginx/html
 
-# Copie des fichiers package.json et package-lock.json (s'ils existent) pour installer les dépendances en premier
-# Cela permet de profiter du cache Docker si les dépendances n'ont pas changé entre deux constructions
-COPY package*.json ./
-
-# Installation des dépendances du projet
-# On utilise npm ci pour une installation reproductible si package-lock.json est présent
-RUN npm ci || npm install
-
-# Copie du reste des fichiers du projet dans le conteneur
-COPY . .
-
-# Par défaut, cette image ne lance pas l'application
-# L'utilisateur pourra spécifier la commande à exécuter lors du lancement du conteneur
-CMD ["npm", "start"]
-
-# Fin du Dockerfile frontend
+# Aucun CMD supplémentaire : l'image nginx lance automatiquement le serveur

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>MoonDust Home</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Exemple de tuiles</h1>
+  <div class="tile mini">Mini</div>
+  <div class="tile petit">Petit</div>
+  <div class="tile moyen">Moyen</div>
+  <div class="tile grand">Grand</div>
+  <div class="tile max">Max</div>
+</body>
+</html>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,20 @@
+body {
+  font-family: Arial, sans-serif;
+  padding: 20px;
+}
+
+.tile {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 5px;
+  background: #e0e0e0;
+  border-radius: 4px;
+  color: #333;
+}
+
+.tile.mini   { width: 50px;  height: 50px;  }
+.tile.petit  { width: 100px; height: 100px; }
+.tile.moyen  { width: 150px; height: 150px; }
+.tile.grand  { width: 200px; height: 200px; }
+.tile.max    { width: 300px; height: 300px; }


### PR DESCRIPTION
## Summary
- serve the frontend with nginx
- show a simple tile layout with five sizes
- document how to run the example via docker compose

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c34e39bc83269bffae96442b75e3