### PR TITLE
Ajoute Elasticsearch et Kibana

### DIFF
--- a/MODE_EMPLOI.md
+++ b/MODE_EMPLOI.md
@@ -36,7 +36,7 @@ Docker va télécharger les images nécessaires puis construire celles du projet
 ## 4. Paramétrage après le lancement
 
 1. Accédez à la page d'accueil du frontend pour vérifier que tout s'affiche correctement.
-2. Pour interagir avec la base de données ou Keycloak, adaptez le fichier `docker-compose.yml` en y ajoutant les services `database` et `keycloak`. Les exemples de `Dockerfile` dans chaque dossier montrent les variables d'environnement utilisables.
+2. Pour interagir avec la base de données, Keycloak, Elasticsearch ou Kibana, adaptez le fichier `docker-compose.yml` en y ajoutant les services `database`, `keycloak`, `elasticsearch` et `kibana`. Les exemples de `Dockerfile` dans chaque dossier montrent les variables d'environnement utilisables.
 3. Si vous devez modifier les ports ou d'autres paramètres (mots de passe, nom de base, etc.), éditez le `docker-compose.yml` avant de relancer `docker compose up`.
 
 ## 5. Arrêter la solution

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Un assemblage de technologie, de composants et d'outils d'une façon cohérente 
 - **backend/** : hébergera la logique serveur de l'application. Là encore, un `Dockerfile` explique chaque étape de la construction de l'image.
 - **database/** : contient l'environnement lié à la base PostgreSQL. Le `Dockerfile` détaille les variables d'environnement utilisées pour initialiser la base.
 - **keycloak/** : fournit Keycloak pour l'authentification et la gestion des utilisateurs. Un `Dockerfile` importe automatiquement le realm de démonstration `demo`.
+- **elastic/** : fournit un conteneur Elasticsearch prêt à l'emploi.
+- **kibana/** : offre l'interface Kibana pour explorer les données.
 
 ### Schémas de base de données
 
@@ -31,3 +33,4 @@ docker compose up --build
 ```
 
 La page sera alors disponible sur `http://localhost:8080` et présente un système de tuiles avec cinq tailles (`mini`, `petit`, `moyen`, `grand`, `max`).
+Elasticsearch sera accessible sur `http://localhost:9200` et Kibana sur `http://localhost:5601`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,15 @@ services:
     build: ./frontend
     ports:
       - "8080:80"
+  elasticsearch:
+    build: ./elastic
+    environment:
+      - discovery.type=single-node
+    ports:
+      - "9200:9200"
+  kibana:
+    build: ./kibana
+    depends_on:
+      - elasticsearch
+    ports:
+      - "5601:5601"

--- a/elastic/Dockerfile
+++ b/elastic/Dockerfile
@@ -1,0 +1,6 @@
+# Dockerfile pour Elasticsearch
+# Utilise l'image officielle avec une configuration simplifiee
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+
+# Mode developpement : un seul noeud
+ENV discovery.type=single-node

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,0 +1,6 @@
+# Dockerfile pour Kibana
+# Utilise l'image officielle de Kibana
+FROM docker.elastic.co/kibana/kibana:8.13.4
+
+# Adresse de connexion a Elasticsearch
+ENV ELASTICSEARCH_HOSTS=http://elasticsearch:9200


### PR DESCRIPTION
## Summary
- ajoute des Dockerfile pour Elasticsearch et Kibana
- déclare ces services dans `docker-compose.yml`
- met à jour la documentation et le mode d'emploi

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c979baf083269c9fc8d2bd708c8d