### PR TITLE
Amélioration du lancement des services

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,9 @@ Depuis la racine du dépôt, exécutez :
 docker compose up --build
 ```
 
+Les services définis dans `docker-compose.yml` disposent désormais d'un mécanisme
+de contrôle d'état (*healthcheck*) et redémarrent automatiquement (`restart: unless-stopped`).
+Cela évite les blocages éventuels lors du lancement.
+
 La page sera alors disponible sur `http://localhost:8080` et présente un système de tuiles avec cinq tailles (`mini`, `petit`, `moyen`, `grand`, `max`).
 Elasticsearch sera accessible sur `http://localhost:9200` et Kibana sur `http://localhost:5601`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,33 @@ services:
     build: ./frontend
     ports:
       - "8080:80"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
   elasticsearch:
     build: ./elastic
     environment:
       - discovery.type=single-node
     ports:
       - "9200:9200"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:9200 > /dev/null"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
   kibana:
     build: ./kibana
     depends_on:
       - elasticsearch
     ports:
       - "5601:5601"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:5601/api/status > /dev/null"]
+      interval: 30s
+      timeout: 10s
+      retries: 5


### PR DESCRIPTION
## Summary
- add healthchecks and restart policies in docker-compose
- mention robustness improvements in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873cb8c32188326a30357c3d1b7215c