### PR TITLE
Add backend contact CRUD example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Chacun de ces dossiers pourra être complété par la suite (code, scripts, conf
 
 ## Lancer un exemple
 
-Un `docker-compose.yml` minimal est fourni pour prévisualiser la page d'accueil servie par Nginx.
+Un `docker-compose.yml` minimal permet maintenant de lancer le frontend, la base PostgreSQL et le backend Express servant l'API contacts.
 Depuis la racine du dépôt, exécutez :
 
 ```bash
@@ -38,3 +38,17 @@ Cela évite les blocages éventuels lors du lancement.
 
 La page sera alors disponible sur `http://localhost:8080` et présente un système de tuiles avec cinq tailles (`mini`, `petit`, `moyen`, `grand`, `max`).
 Elasticsearch sera accessible sur `http://localhost:9200` et Kibana sur `http://localhost:5601`.
+
+## API Backend
+
+Un premier exemple d'API permet maintenant de gerer des contacts dans la base PostgreSQL. La table `metaappback.contact` stocke un nom, un numero de telephone, un email et un type numerique (0 = inconnu, 1 = entreprise, 2 = humain).
+
+Les routes disponibles sur le backend sont :
+
+- `GET /contacts` : liste tous les contacts
+- `GET /contacts/:id` : retourne un contact
+- `POST /contacts` : cree un contact
+- `PUT /contacts/:id` : met a jour un contact
+- `DELETE /contacts/:id` : supprime un contact
+
+Le serveur Node.js se lance avec `npm start` dans le dossier `backend`.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,82 @@
+const express = require('express');
+const { Pool } = require('pg');
+
+const app = express();
+app.use(express.json());
+
+const pool = new Pool({
+  host: process.env.DB_HOST || 'database',
+  port: process.env.DB_PORT || 5432,
+  user: process.env.DB_USER || 'appuser',
+  password: process.env.DB_PASSWORD || 'apppassword',
+  database: process.env.DB_DATABASE || 'appdb'
+});
+
+app.get('/contacts', async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM metaappback.contact ORDER BY id');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'internal error' });
+  }
+});
+
+app.get('/contacts/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { rows } = await pool.query('SELECT * FROM metaappback.contact WHERE id = $1', [id]);
+    if (rows.length === 0) return res.sendStatus(404);
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'internal error' });
+  }
+});
+
+app.post('/contacts', async (req, res) => {
+  try {
+    const { name, phone, email, kind } = req.body;
+    const { rows } = await pool.query(
+      'INSERT INTO metaappback.contact (name, phone, email, kind) VALUES ($1, $2, $3, $4) RETURNING *',
+      [name, phone, email, kind]
+    );
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'internal error' });
+  }
+});
+
+app.put('/contacts/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { name, phone, email, kind } = req.body;
+    const result = await pool.query(
+      'UPDATE metaappback.contact SET name=$1, phone=$2, email=$3, kind=$4 WHERE id=$5 RETURNING *',
+      [name, phone, email, kind, id]
+    );
+    if (result.rowCount === 0) return res.sendStatus(404);
+    res.json(result.rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'internal error' });
+  }
+});
+
+app.delete('/contacts/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const result = await pool.query('DELETE FROM metaappback.contact WHERE id=$1', [id]);
+    if (result.rowCount === 0) return res.sendStatus(404);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'internal error' });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "start:prod": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.11.1"
+  }
+}

--- a/database/initdb/002_create_contact.sql
+++ b/database/initdb/002_create_contact.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS metaappback.contact (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    phone VARCHAR(50),
+    email VARCHAR(255),
+    kind INTEGER NOT NULL DEFAULT 0
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,3 +34,26 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+  database:
+    build: ./database
+    ports:
+      - "5432:5432"
+    restart: unless-stopped
+  backend:
+    build: ./backend
+    environment:
+      - DB_HOST=database
+      - DB_PORT=5432
+      - DB_USER=appuser
+      - DB_PASSWORD=apppassword
+      - DB_DATABASE=appdb
+    ports:
+      - "3000:3000"
+    depends_on:
+      - database
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:3000/contacts > /dev/null"]
+      interval: 30s
+      timeout: 10s
+      retries: 5


### PR DESCRIPTION
## Summary
- implement basic Express server and CRUD routes for contacts
- describe contact API in README
- add Postgres table creation script
- include backend and database services in `docker-compose.yml`

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68761b5cd5208326895e49db584391ee