### PR TITLE
Refine Docker setup for Node backend and React frontend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,15 +1,15 @@
-# Backend Dockerfile (simplifié)
-FROM node:20
-
-# Dossier de travail
+# Backend Dockerfile
+FROM node:20-alpine AS deps
 WORKDIR /app
-
-# Copie des dépendances et installation
 COPY package*.json ./
-RUN npm ci
+RUN npm ci --omit=dev
 
-# Copie du code source
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-
-# Lancement de l’application en production
+USER node
+EXPOSE 3000
 CMD ["npm", "run", "start:prod"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,14 @@ services:
       - DB_USER=appuser
       - DB_PASSWORD=apppassword
       - DB_DATABASE=appdb
+      - NODE_ENV=production
     ports:
       - "3000:3000"
     depends_on:
       - database
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "curl -fs http://localhost:3000/contacts > /dev/null"]
+      test: ["CMD-SHELL", "curl -fs http://localhost:3000/ > /dev/null"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -30,9 +31,12 @@ services:
     build: ./frontend
     ports:
       - "8080:80"
+    depends_on:
+      - backend
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost"]
       interval: 30s
       timeout: 10s
       retries: 5
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,13 @@
-FROM nginx:alpine
+# Frontend Dockerfile
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
 
-# Copie directe du HTML dans le dossier de Nginx
-COPY index.html /usr/share/nginx/html/index.html
+FROM nginx:alpine AS runtime
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+


### PR DESCRIPTION
## Summary
- harden Node backend image with a multistage Dockerfile
- build React frontend and serve it from nginx
- streamline docker-compose for backend/frontend and exclude optional services

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a71d838ac48326b43a87369f89af63