### PR TITLE
feat: load env config and harden backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Application environment
+NODE_ENV=development
+LOG_LEVEL=info
+
+# Ports
+PORT=3000
+DB_PORT=5432
+FRONTEND_PORT=8080
+
+# CORS
+CORS_ORIGIN=http://localhost:8080
+
+# Database
+DB_HOST=database
+DB_USER=appuser
+DB_PASSWORD=apppassword
+DB_DATABASE=appdb

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Node modules
+**/node_modules
+
+# Environment files
+.env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,8 @@
 FROM node:20-alpine AS deps
 WORKDIR /app
 COPY package*.json ./
-RUN npm install --omit=dev
+# Install all dependencies (including dev for development use)
+RUN npm install
 
 FROM node:20-alpine AS runner
 WORKDIR /app

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,28 +1,43 @@
+require('dotenv').config();
+
 const express = require('express');
 const cors = require('cors');
+const helmet = require('helmet');
+const pinoHttp = require('pino-http');
+const logger = require('./logger');
 const pool = require('./db');
 
 const app = express();
 const port = process.env.PORT || 3000;
 
-app.use(cors());
+const corsOptions = {
+  origin: process.env.CORS_ORIGIN,
+  optionsSuccessStatus: 200,
+};
+
+app.use(helmet());
+app.use(cors(corsOptions));
 app.use(express.json());
+app.use(pinoHttp({ logger }));
+
+app.get('/healthcheck', (req, res) => {
+  res.json({ status: 'ok' });
+});
 
 app.get('/', (req, res) => {
   res.json({ message: 'Hello from backend' });
 });
 
-app.get('/api/entity', async (req, res) => {
+app.get('/api/entity', async (req, res, next) => {
   try {
     const result = await pool.query('SELECT id, name, created_at FROM entity ORDER BY id DESC');
     res.json(result.rows);
   } catch (err) {
-    console.error('Error fetching entities', err);
-    res.status(500).json({ error: 'Internal server error' });
+    next(err);
   }
 });
 
-app.post('/api/entity', async (req, res) => {
+app.post('/api/entity', async (req, res, next) => {
   const { name } = req.body;
   if (typeof name !== 'string' || !name.trim()) {
     return res.status(400).json({ error: 'Invalid name' });
@@ -31,14 +46,24 @@ app.post('/api/entity', async (req, res) => {
     const result = await pool.query('INSERT INTO entity (name) VALUES ($1) RETURNING id, name, created_at', [name.trim()]);
     res.status(201).json(result.rows[0]);
   } catch (err) {
-    console.error('Error inserting entity', err);
-    res.status(500).json({ error: 'Internal server error' });
+    next(err);
   }
+});
+
+// 404 handler
+app.use((req, res, next) => {
+  res.status(404).json({ error: 'Not Found' });
+});
+
+// Global error handler
+app.use((err, req, res, next) => {
+  req.log.error(err);
+  res.status(err.status || 500).json({ error: err.message || 'Internal server error' });
 });
 
 if (require.main === module) {
   app.listen(port, () => {
-    console.log(`Backend listening on port ${port}`);
+    logger.info(`Backend listening on port ${port}`);
   });
 }
 

--- a/backend/logger.js
+++ b/backend/logger.js
@@ -1,0 +1,7 @@
+const pino = require('pino');
+
+const logger = pino({
+  level: process.env.LOG_LEVEL || 'info',
+});
+
+module.exports = logger;

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,16 +4,23 @@
   "description": "Minimal Express backend",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "start:prod": "node index.js",
+    "dev": "nodemon index.js",
     "test": "jest"
   },
   "dependencies": {
     "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
     "express": "^4.19.2",
-    "pg": "^8.11.3"
+    "helmet": "^7.0.0",
+    "pg": "^8.11.3",
+    "pino": "^8.15.0",
+    "pino-http": "^8.5.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",
-    "supertest": "^6.3.4"
+    "supertest": "^6.3.4",
+    "nodemon": "^3.0.3"
   }
 }

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -5,16 +5,8 @@
 # Image officielle PostgreSQL recommandée pour la production
 FROM postgres:16
 
-# Les variables d'environnement suivantes permettent d'initialiser la base de données
-# POSTGRES_USER : nom d'utilisateur par défaut
-# POSTGRES_PASSWORD : mot de passe de l'utilisateur
-# POSTGRES_DB : nom de la base de données créée au démarrage
-# Ici, on se contente de les déclarer pour montrer comment les utiliser
-# Elles pourront être remplacées ou complétées dans un fichier docker-compose ou à
-# l'exécution via la ligne de commande
-ENV POSTGRES_USER=appuser \
-    POSTGRES_PASSWORD=apppassword \
-    POSTGRES_DB=appdb
+# Les variables d'environnement (POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB)
+# seront fournies au moment du démarrage via docker-compose
 
 # Optionnel : ajout d'un script d'initialisation placé dans le dossier docker-entrypoint-initdb.d
 # Tout fichier .sql ou .sh présent dans ce répertoire sera exécuté au démarrage

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+  backend:
+    command: npm run dev
+    environment:
+      NODE_ENV: development
+    volumes:
+      - ./backend:/app
+      - /app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,26 +3,33 @@ version: '3.8'
 services:
   database:
     build: ./database
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_DATABASE}
     ports:
-      - "5432:5432"
+      - "${DB_PORT}:5432"
     restart: unless-stopped
 
   backend:
     build: ./backend
     environment:
-      - DB_HOST=database
-      - DB_PORT=5432
-      - DB_USER=appuser
-      - DB_PASSWORD=apppassword
-      - DB_DATABASE=appdb
-      - NODE_ENV=production
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_DATABASE: ${DB_DATABASE}
+      NODE_ENV: ${NODE_ENV}
+      PORT: ${PORT}
+      CORS_ORIGIN: ${CORS_ORIGIN}
+      LOG_LEVEL: ${LOG_LEVEL}
     ports:
-      - "3000:3000"
+      - "${PORT}:${PORT}"
     depends_on:
       - database
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "curl -fs http://localhost:3000/ > /dev/null"]
+      test: ["CMD-SHELL", "curl -fs http://localhost:${PORT}/healthcheck > /dev/null || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -30,7 +37,7 @@ services:
   frontend:
     build: ./frontend
     ports:
-      - "8080:80"
+      - "${FRONTEND_PORT}:80"
     depends_on:
       - backend
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- externalize service configuration to .env and ignore secrets
- secure Express with helmet, CORS, structured logs, and healthcheck
- run backend in dev mode via compose override

## Testing
- `npm test`
- `docker-compose --env-file .env.example config`

------
https://chatgpt.com/codex/tasks/task_e_68a728b692008326bb054dbe0c49973e