### PR TITLE
feat: add global status page

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6,6 +6,7 @@ const helmet = require('helmet');
 const pinoHttp = require('pino-http');
 const logger = require('./logger');
 const pool = require('./db');
+const statusRouter = require('./src/routes/status');
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -23,6 +24,8 @@ app.use(pinoHttp({ logger }));
 app.get('/healthcheck', (req, res) => {
   res.json({ status: 'ok' });
 });
+
+app.use('/status', statusRouter);
 
 app.get('/', (req, res) => {
   res.json({ message: 'Hello from backend' });

--- a/backend/src/routes/status.js
+++ b/backend/src/routes/status.js
@@ -1,0 +1,49 @@
+const express = require('express');
+const pool = require('../../db');
+
+const router = express.Router();
+const port = process.env.PORT || 3000;
+
+router.get('/', async (req, res) => {
+  const result = {
+    backend: { status: 'ok', endpoints: {} },
+    database: { status: 'ok', migration: 'ok' },
+  };
+
+  // Test database connection
+  try {
+    await pool.query('SELECT 1');
+  } catch (err) {
+    result.database.status = 'error';
+    result.database.error = err.message;
+  }
+
+  // Verify "entity" table exists
+  try {
+    const tableRes = await pool.query("SELECT to_regclass('public.entity') AS table_exists");
+    if (!tableRes.rows[0] || !tableRes.rows[0].table_exists) {
+      result.database.migration = 'missing';
+      result.database.status = 'error';
+    }
+  } catch (err) {
+    result.database.migration = 'error';
+    result.database.status = 'error';
+    result.database.error = err.message;
+  }
+
+  // Test backend endpoint
+  try {
+    const response = await fetch(`http://localhost:${port}/api/entity`);
+    result.backend.endpoints['/api/entity'] = `${response.status} ${response.statusText}`;
+    if (!response.ok) {
+      result.backend.status = 'error';
+    }
+  } catch (err) {
+    result.backend.status = 'error';
+    result.backend.endpoints['/api/entity'] = err.message;
+  }
+
+  res.json(result);
+});
+
+module.exports = router;

--- a/backend/test/status.test.js
+++ b/backend/test/status.test.js
@@ -1,0 +1,44 @@
+const request = require('supertest');
+jest.mock('../db', () => ({ query: jest.fn() }));
+const db = require('../db');
+const app = require('../index');
+
+const realFetch = global.fetch;
+
+describe('Status API', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    global.fetch = realFetch;
+  });
+
+  test('GET /status returns ok statuses', async () => {
+    db.query
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ rows: [{ table_exists: 'entity' }] });
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      statusText: 'OK',
+    });
+    const res = await request(app).get('/status');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      backend: { status: 'ok', endpoints: { '/api/entity': '200 OK' } },
+      database: { status: 'ok', migration: 'ok' },
+    });
+  });
+
+  test('GET /status handles errors', async () => {
+    db.query.mockRejectedValue(new Error('DB down'));
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 404,
+      ok: false,
+      statusText: 'Not Found',
+    });
+    const res = await request(app).get('/status');
+    expect(res.statusCode).toBe(200);
+    expect(res.body.database.status).toBe('error');
+    expect(res.body.backend.status).toBe('error');
+    expect(res.body.backend.endpoints['/api/entity']).toBe('404 Not Found');
+  });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import { AppBar, Toolbar, Typography, Button } from '@mui/material';
 import CreateEntity from './pages/CreateEntity.jsx';
 import EntityList from './pages/EntityList.jsx';
+import Status from './pages/Status.jsx';
 
 export default function App() {
   return (
@@ -14,12 +15,14 @@ export default function App() {
           </Typography>
           <Button color="inherit" component={Link} to="/create">Create</Button>
           <Button color="inherit" component={Link} to="/list">List</Button>
+          <Button color="inherit" component={Link} to="/status">Status</Button>
         </Toolbar>
       </AppBar>
       <Routes>
         <Route path="/" element={<CreateEntity />} />
         <Route path="/create" element={<CreateEntity />} />
         <Route path="/list" element={<EntityList />} />
+        <Route path="/status" element={<Status />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/pages/Status.jsx
+++ b/frontend/src/pages/Status.jsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { Container, Card, CardContent, Typography, List, ListItem, Badge } from '@mui/material';
+
+export default function Status() {
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/status')
+      .then((res) => res.json())
+      .then(setData)
+      .catch(() => {});
+  }, []);
+
+  if (!data) {
+    return (
+      <Container sx={{ mt: 4 }}>
+        <Typography>Loading...</Typography>
+      </Container>
+    );
+  }
+
+  return (
+    <Container sx={{ mt: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Card>
+        <CardContent>
+          <Typography variant="h5">Database</Typography>
+          <Badge
+            color={data.database.status === 'ok' ? 'success' : 'error'}
+            badgeContent={data.database.status}
+            sx={{ ml: 2 }}
+          >
+            <span />
+          </Badge>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent>
+          <Typography variant="h5">Backend</Typography>
+          <Badge
+            color={data.backend.status === 'ok' ? 'success' : 'error'}
+            badgeContent={data.backend.status}
+            sx={{ ml: 2 }}
+          >
+            <span />
+          </Badge>
+          <List>
+            {Object.entries(data.backend.endpoints).map(([ep, status]) => (
+              <ListItem key={ep}>
+                <Typography>{`${ep}: ${status}`}</Typography>
+              </ListItem>
+            ))}
+          </List>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/status` route that checks database, migration, and API endpoint
- expose status page in React to display backend and database health
- cover new route with Jest tests

## Testing
- `cd backend && npm test`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a74bcb343883269907145baffd0ae2